### PR TITLE
Ported zstd-jni to use java/lang/MemoryAddress

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,22 +157,7 @@ description := "JNI bindings for Zstd native library that provides fast and high
 
 packageOptions in (Compile, packageBin) ++= Seq(
   Package.ManifestAttributes(new java.util.jar.Attributes.Name("Automatic-Module-Name") -> "com.github.luben.zstd_jni"),
-  Package.ManifestAttributes(new java.util.jar.Attributes.Name("Bundle-NativeCode") ->
-  {s"""darwin/x86_64/libzstd-jni-${version.value}.dylib;osname=MacOS;osname=MacOSX;processor=x86_64,
-      |darwin/aarch64/libzstd-jni-${version.value}.dylib;osname=MacOS;osname=MacOSX;processor=aarch64,
-      |freebsd/amd64/libzstd-jni-${version.value}.so;osname=FreeBSD;processor=amd64,
-      |freebsd/i386/libzstd-jni-${version.value}.so;osname=FreeBSD;processor=i386,
-      |linux/aarch64/libzstd-jni-${version.value}.so;osname=Linux;processor=aarch64,
-      |linux/amd64/libzstd-jni-${version.value}.so;osname=Linux;processor=amd64,
-      |linux/arm/libzstd-jni-${version.value}.so;osname=Linux;processor=arm,
-      |linux/i386/libzstd-jni-${version.value}.so;osname=Linux;processor=i386,
-      |linux/mips64/libzstd-jni-${version.value}.so;osname=Linux;processor=mips64,
-      |linux/loongarch64/libzstd-jni-${version.value}.so;osname=Linux;processor=loongarch64,
-      |linux/ppc64/libzstd-jni-${version.value}.so;osname=Linux;processor=ppc64,
-      |linux/ppc64le/libzstd-jni-${version.value}.so;osname=Linux;processor=ppc64le,
-      |linux/s390x/libzstd-jni-${version.value}.so;osname=Linux;processor=s390x,
-      |win/amd64/libzstd-jni-${version.value}.dll;osname=Win32;processor=amd64,
-      |win/x86/libzstd-jni-${version.value}.dll;osname=Win32;processor=x86""".stripMargin}),
+  Package.ManifestAttributes(new java.util.jar.Attributes.Name("Bundle-NativeCode") -> "freebsd/aarch64/libzstd-jni-${version.value}.so;osname=FreeBSD;processor=aarch64"),
 )
 
 pomExtra := (

--- a/sbt
+++ b/sbt
@@ -51,7 +51,7 @@ declare -r sbt_launch_ivy_snapshot_repo="https://repo.scala-sbt.org/scalasbt/ivy
 declare -r sbt_launch_mvn_release_repo="https://repo.scala-sbt.org/scalasbt/maven-releases"
 declare -r sbt_launch_mvn_snapshot_repo="https://repo.scala-sbt.org/scalasbt/maven-snapshots"
 
-declare -r default_jvm_opts_common="-Xms512m -Xss2m -XX:MaxInlineLevel=18"
+declare -r default_jvm_opts_common="-Xms512m -Xmx2G"
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy -Dsbt.coursier.home=project/.coursier"
 
 declare sbt_jar sbt_dir sbt_create sbt_version sbt_script sbt_new

--- a/src/main/java/com/github/luben/zstd/BaseZstdBufferDecompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/BaseZstdBufferDecompressingStreamNoFinalizer.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 public abstract class BaseZstdBufferDecompressingStreamNoFinalizer implements Closeable {
-    protected long stream;
+    protected MemoryAddress stream;
     protected ByteBuffer source;
     protected boolean closed = false;
     private boolean finishedFrame = false;
@@ -143,11 +143,11 @@ public abstract class BaseZstdBufferDecompressingStreamNoFinalizer implements Cl
      */
     public abstract int read(ByteBuffer target) throws IOException;
 
-    abstract long createDStream();
+    abstract MemoryAddress createDStream();
 
-    abstract long freeDStream(long stream);
+    abstract long freeDStream(MemoryAddress stream);
 
-    abstract long initDStream(long stream);
+    abstract long initDStream(MemoryAddress stream);
 
-    abstract long decompressStream(long stream, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
+    abstract long decompressStream(MemoryAddress stream, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
 }

--- a/src/main/java/com/github/luben/zstd/Zstd.java
+++ b/src/main/java/com/github/luben/zstd/Zstd.java
@@ -559,9 +559,9 @@ public class Zstd {
 
     /* Advance API */
     public static native int loadDictDecompress(MemoryAddress stream, byte[] dict, int dict_size);
-    public static native int loadFastDictDecompress(MemoryAddress stream, MemoryAddress dictNativePtr);
+    public static native int loadFastDictDecompress(MemoryAddress stream, ZstdDictDecompress dict);
     public static native int loadDictCompress(MemoryAddress stream, byte[] dict, int dict_size);
-    public static native int loadFastDictCompress(MemoryAddress stream, MemoryAddress dictNativePtr);
+    public static native int loadFastDictCompress(MemoryAddress stream, ZstdDictCompress dict);
     public static native int setCompressionChecksums(MemoryAddress stream, boolean useChecksums);
     public static native int setCompressionMagicless(MemoryAddress stream, boolean useMagicless);
     public static native int setCompressionLevel(MemoryAddress stream, int level);

--- a/src/main/java/com/github/luben/zstd/Zstd.java
+++ b/src/main/java/com/github/luben/zstd/Zstd.java
@@ -7,6 +7,8 @@ import com.github.luben.zstd.util.Native;
 import com.github.luben.zstd.ZstdCompressCtx;
 import com.github.luben.zstd.ZstdDecompressCtx;
 
+import java.lang.MemoryAddress;
+
 public class Zstd {
 
     static {
@@ -171,7 +173,7 @@ public class Zstd {
      * @return  the number of bytes written into buffer 'dst' or an error code if
      *          it fails (which can be tested using ZSTD_isError())
      */
-    public static native long compressUnsafe(long dst, long dstSize, long src, long srcSize, int level, boolean checksumFlag);
+    public static native long compressUnsafe(MemoryAddress dst, long dstSize, MemoryAddress src, long srcSize, int level, boolean checksumFlag);
 
     /**
      * Compresses buffer 'src' into direct buffer 'dst'.
@@ -188,7 +190,7 @@ public class Zstd {
      * @return  the number of bytes written into buffer 'dst' or an error code if
      *          it fails (which can be tested using ZSTD_isError())
      */
-    public static long compressUnsafe(long dst, long dstSize, long src, long srcSize, int level) {
+    public static long compressUnsafe(MemoryAddress dst, long dstSize, MemoryAddress src, long srcSize, int level) {
         return compressUnsafe(dst, dstSize, src, srcSize, level, false);
     }
 
@@ -451,7 +453,7 @@ public class Zstd {
      *          or an errorCode if it fails (which can be tested using ZSTD_isError())
      *
      */
-    public static native long decompressUnsafe(long dst, long dstSize, long src, long srcSize);
+    public static native long decompressUnsafe(MemoryAddress dst, long dstSize, MemoryAddress src, long srcSize);
 
     /**
      * Decompresses buffer 'src' into buffer 'dst' with dictionary.
@@ -556,27 +558,27 @@ public class Zstd {
     }
 
     /* Advance API */
-    public static native int loadDictDecompress(long stream, byte[] dict, int dict_size);
-    public static native int loadFastDictDecompress(long stream, ZstdDictDecompress dict);
-    public static native int loadDictCompress(long stream, byte[] dict, int dict_size);
-    public static native int loadFastDictCompress(long stream, ZstdDictCompress dict);
-    public static native int setCompressionChecksums(long stream, boolean useChecksums);
-    public static native int setCompressionMagicless(long stream, boolean useMagicless);
-    public static native int setCompressionLevel(long stream, int level);
-    public static native int setCompressionLong(long stream, int windowLog);
-    public static native int setCompressionWorkers(long stream, int workers);
-    public static native int setCompressionOverlapLog(long stream, int overlapLog);
-    public static native int setCompressionJobSize(long stream, int jobSize);
-    public static native int setCompressionTargetLength(long stream, int targetLength);
-    public static native int setCompressionMinMatch(long stream, int minMatch);
-    public static native int setCompressionSearchLog(long stream, int searchLog);
-    public static native int setCompressionChainLog(long stream, int chainLog);
-    public static native int setCompressionHashLog(long stream, int hashLog);
-    public static native int setCompressionWindowLog(long stream, int windowLog);
-    public static native int setCompressionStrategy(long stream, int strategy);
-    public static native int setDecompressionLongMax(long stream, int windowLogMax);
-    public static native int setDecompressionMagicless(long stream, boolean useMagicless);
-    public static native int setRefMultipleDDicts(long stream, boolean useMultiple);
+    public static native int loadDictDecompress(MemoryAddress stream, byte[] dict, int dict_size);
+    public static native int loadFastDictDecompress(MemoryAddress stream, MemoryAddress dictNativePtr);
+    public static native int loadDictCompress(MemoryAddress stream, byte[] dict, int dict_size);
+    public static native int loadFastDictCompress(MemoryAddress stream, MemoryAddress dictNativePtr);
+    public static native int setCompressionChecksums(MemoryAddress stream, boolean useChecksums);
+    public static native int setCompressionMagicless(MemoryAddress stream, boolean useMagicless);
+    public static native int setCompressionLevel(MemoryAddress stream, int level);
+    public static native int setCompressionLong(MemoryAddress stream, int windowLog);
+    public static native int setCompressionWorkers(MemoryAddress stream, int workers);
+    public static native int setCompressionOverlapLog(MemoryAddress stream, int overlapLog);
+    public static native int setCompressionJobSize(MemoryAddress stream, int jobSize);
+    public static native int setCompressionTargetLength(MemoryAddress stream, int targetLength);
+    public static native int setCompressionMinMatch(MemoryAddress stream, int minMatch);
+    public static native int setCompressionSearchLog(MemoryAddress stream, int searchLog);
+    public static native int setCompressionChainLog(MemoryAddress stream, int chainLog);
+    public static native int setCompressionHashLog(MemoryAddress stream, int hashLog);
+    public static native int setCompressionWindowLog(MemoryAddress stream, int windowLog);
+    public static native int setCompressionStrategy(MemoryAddress stream, int strategy);
+    public static native int setDecompressionLongMax(MemoryAddress stream, int windowLogMax);
+    public static native int setDecompressionMagicless(MemoryAddress stream, boolean useMagicless);
+    public static native int setRefMultipleDDicts(MemoryAddress stream, boolean useMultiple);
 
     /* Utility methods */
 

--- a/src/main/java/com/github/luben/zstd/ZstdBufferDecompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdBufferDecompressingStreamNoFinalizer.java
@@ -28,22 +28,22 @@ public class ZstdBufferDecompressingStreamNoFinalizer extends BaseZstdBufferDeco
     }
 
     @Override
-    long createDStream() {
+    MemoryAddress createDStream() {
         return createDStreamNative();
     }
 
     @Override
-    long freeDStream(long stream) {
+    long freeDStream(MemoryAddress stream) {
         return freeDStreamNative(stream);
     }
 
     @Override
-    long initDStream(long stream) {
+    long initDStream(MemoryAddress stream) {
         return initDStreamNative(stream);
     }
 
     @Override
-    long decompressStream(long stream, ByteBuffer dst, int dstBufPos, int dstSize, ByteBuffer src, int srcBufPos, int srcSize) {
+    long decompressStream(MemoryAddress stream, ByteBuffer dst, int dstBufPos, int dstSize, ByteBuffer src, int srcBufPos, int srcSize) {
         if (!src.hasArray()) {
             throw new IllegalArgumentException("provided source ByteBuffer lacks array");
         }
@@ -63,13 +63,13 @@ public class ZstdBufferDecompressingStreamNoFinalizer extends BaseZstdBufferDeco
         return (int) recommendedDOutSizeNative();
     }
 
-    private native long createDStreamNative();
+    private native MemoryAddress createDStreamNative();
 
-    private native long freeDStreamNative(long stream);
+    private native long freeDStreamNative(MemoryAddress stream);
 
-    private native long initDStreamNative(long stream);
+    private native long initDStreamNative(MemoryAddress stream);
 
-    private native long decompressStreamNative(long stream, byte[] dst, int dstOffset, int dstSize, byte[] src, int srcOffset, int srcSize);
+    private native long decompressStreamNative(MemoryAddress stream, byte[] dst, int dstOffset, int dstSize, byte[] src, int srcOffset, int srcSize);
 
     private static native long recommendedDOutSizeNative();
 }

--- a/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
@@ -311,7 +311,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
         }
         return this;
     }
-    private native long loadCDict0(long ptr, byte[] dict);
+    private native long loadCDict0(MemoryAddress ptr, byte[] dict);
 
     /**
      * Tells how much data has been ingested (read from input),
@@ -321,7 +321,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
         ensureOpen();
         return getFrameProgression0(nativePtr);
     }
-    private static native ZstdFrameProgression getFrameProgression0(long ptr);
+    private static native ZstdFrameProgression getFrameProgression0(MemoryAddress ptr);
 
     /**
      * Clear all state and parameters from the compression context. This leaves the object in a
@@ -334,7 +334,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
             throw new ZstdException(result);
         }
     }
-    private static native long reset0(long ptr);
+    private static native long reset0(MemoryAddress ptr);
 
     /**
      * Promise to compress a certain number of source bytes. Knowing the number of bytes to compress
@@ -351,7 +351,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
             throw new ZstdException(result);
         }
     }
-    private static native long setPledgedSrcSize0(long ptr, long srcSize);
+    private static native long setPledgedSrcSize0(MemoryAddress ptr, long srcSize);
 
     /**
      * Compress as much of the <code>src</code> {@link ByteBuffer} into the <code>dst</code> {@link
@@ -381,7 +381,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
      * bit is set if an error occurred. If an error occurred, the lowest 31 bits encode a zstd error
      * code. Otherwise, the lowest 31 bits are the new position of the source buffer.
      */
-    private static native long compressDirectByteBufferStream0(long ptr, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcSize, int srcOffset, int endOp);
+    private static native long compressDirectByteBufferStream0(MemoryAddress ptr, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcSize, int srcOffset, int endOp);
 
     /**
      * Compresses buffer 'srcBuff' into buffer 'dstBuff' reusing this ZstdCompressCtx.
@@ -424,7 +424,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
         }
     }
 
-    private static native long compressDirectByteBuffer0(long ptr, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
+    private static native long compressDirectByteBuffer0(MemoryAddress ptr, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
 
     /**
      * Compresses byte array 'srcBuff' into byte array 'dstBuff' reusing this ZstdCompressCtx.
@@ -459,7 +459,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
         }
     }
 
-    private static native long compressByteArray0(long ptr, byte[] dst, int dstOffset, int dstSize, byte[] src, int srcOffset, int srcSize);
+    private static native long compressByteArray0(MemoryAddress ptr, byte[] dst, int dstOffset, int dstSize, byte[] src, int srcOffset, int srcSize);
 
     /* Convenience methods */
 

--- a/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java
@@ -12,13 +12,13 @@ public class ZstdCompressCtx extends AutoCloseBase {
         Native.load();
     }
 
-    private long nativePtr = 0;
+    private MemoryAddress nativePtr = null;
 
     private ZstdDictCompress compression_dict = null;
 
-    private static native long init();
+    private static native MemoryAddress init();
 
-    private static native void free(long ptr);
+    private static native void free(MemoryAddress ptr);
 
     /**
      * Create a context for faster compress operations
@@ -26,21 +26,21 @@ public class ZstdCompressCtx extends AutoCloseBase {
      */
     public ZstdCompressCtx() {
         nativePtr = init();
-        if (0 == nativePtr) {
+        if (MemoryAddress.isNull(nativePtr)) {
             throw new IllegalStateException("ZSTD_createCompressCtx failed");
         }
         storeFence();
     }
 
     void doClose() {
-        if (nativePtr != 0) {
+        if (!MemoryAddress.isNull(nativePtr)) {
             free(nativePtr);
-            nativePtr = 0;
+            nativePtr = null;
         }
     }
 
     private void ensureOpen() {
-        if (nativePtr == 0) {
+        if (MemoryAddress.isNull(nativePtr)) {
             throw new IllegalStateException("Compression context is closed");
         }
     }
@@ -57,7 +57,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
         return this;
     }
 
-    private static native void setLevel0(long ptr, int level);
+    private static native void setLevel0(MemoryAddress ptr, int level);
 
     /**
      * Enable or disable magicless frames
@@ -82,7 +82,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
         releaseSharedLock();
         return this;
     }
-    private static native void setChecksum0(long ptr, boolean checksumFlag);
+    private static native void setChecksum0(MemoryAddress ptr, boolean checksumFlag);
 
 
     public ZstdCompressCtx setWorkers(int workers) {
@@ -236,7 +236,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
         releaseSharedLock();
         return this;
     }
-    private static native void setContentSize0(long ptr, boolean contentSizeFlag);
+    private static native void setContentSize0(MemoryAddress ptr, boolean contentSizeFlag);
 
     /**
      * Enable or disable dictID
@@ -249,7 +249,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
         releaseSharedLock();
         return this;
     }
-    private static native void setDictID0(long ptr, boolean dictIDFlag);
+    private static native void setDictID0(MemoryAddress ptr, boolean dictIDFlag);
 
     /**
      * Enable or disable LongDistanceMatching and set the window size
@@ -290,7 +290,7 @@ public class ZstdCompressCtx extends AutoCloseBase {
         }
         return this;
     }
-    private native long loadCDictFast0(long ptr, ZstdDictCompress dict);
+    private native long loadCDictFast0(MemoryAddress ptr, ZstdDictCompress dict);
 
     /**
      * Load compression dictionary to be used for subsequently compressed frames.

--- a/src/main/java/com/github/luben/zstd/ZstdDecompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDecompressCtx.java
@@ -12,12 +12,12 @@ public class ZstdDecompressCtx extends AutoCloseBase {
         Native.load();
     }
 
-    private long nativePtr = 0;
+    private MemoryAddress nativePtr = 0;
     private ZstdDictDecompress decompression_dict = null;
 
-    private static native long init();
+    private static native MemoryAddress init();
 
-    private static native void free(long nativePtr);
+    private static native void free(MemoryAddress nativePtr);
 
     /**
      * Create a context for faster compress operations
@@ -25,16 +25,16 @@ public class ZstdDecompressCtx extends AutoCloseBase {
      */
     public ZstdDecompressCtx() {
         nativePtr = init();
-        if (0 == nativePtr) {
+        if (MemoryAddress.isNull(nativePtr)) {
             throw new IllegalStateException("ZSTD_createDeCompressCtx failed");
         }
         storeFence();
     }
 
     void doClose() {
-        if (nativePtr != 0) {
+        if (!MemoryAddress.isNull(nativePtr)) {
             free(nativePtr);
-            nativePtr = 0;
+            nativePtr = null;
         }
     }
 
@@ -72,7 +72,7 @@ public class ZstdDecompressCtx extends AutoCloseBase {
         }
         return this;
     }
-    private static native long loadDDictFast0(long nativePtr, ZstdDictDecompress dict);
+    private static native long loadDDictFast0(MemoryAddress nativePtr, ZstdDictDecompress dict);
 
     /**
      * Load decompression dictionary.
@@ -93,7 +93,7 @@ public class ZstdDecompressCtx extends AutoCloseBase {
         }
         return this;
     }
-    private static native long loadDDict0(long nativePtr, byte[] dict);
+    private static native long loadDDict0(MemoryAddress nativePtr, byte[] dict);
 
     /**
      * Clear all state and parameters from the decompression context. This leaves the object in a
@@ -103,10 +103,10 @@ public class ZstdDecompressCtx extends AutoCloseBase {
         ensureOpen();
         reset0(nativePtr);
     }
-    private static native void reset0(long nativePtr);
+    private static native void reset0(MemoryAddress nativePtr);
 
     private void ensureOpen() {
-        if (nativePtr == 0) {
+        if (MemoryAddress.isNull(nativePtr)) {
             throw new IllegalStateException("Decompression context is closed");
         }
     }
@@ -138,7 +138,7 @@ public class ZstdDecompressCtx extends AutoCloseBase {
      * bit is set if an error occurred. If an error occurred, the lowest 31 bits encode a zstd error
      * code. Otherwise, the lowest 31 bits are the new position of the source buffer.
      */
-    private static native long decompressDirectByteBufferStream0(long nativePtr, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
+    private static native long decompressDirectByteBufferStream0(MemoryAddress nativePtr, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
 
     /**
      * Decompresses buffer 'srcBuff' into buffer 'dstBuff' using this ZstdDecompressCtx.
@@ -180,7 +180,7 @@ public class ZstdDecompressCtx extends AutoCloseBase {
         }
     }
 
-    private static native long decompressDirectByteBuffer0(long nativePtr, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
+    private static native long decompressDirectByteBuffer0(MemoryAddress nativePtr, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
 
     /**
      * Decompresses byte array 'srcBuff' into byte array 'dstBuff' using this ZstdDecompressCtx.
@@ -213,7 +213,7 @@ public class ZstdDecompressCtx extends AutoCloseBase {
         }
     }
 
-    private static native long decompressByteArray0(long nativePtr, byte[] dst, int dstOffset, int dstSize, byte[] src, int srcOffset, int srcSize);
+    private static native long decompressByteArray0(MemoryAddress nativePtr, byte[] dst, int dstOffset, int dstSize, byte[] src, int srcOffset, int srcSize);
 
     /* Covenience methods */
 

--- a/src/main/java/com/github/luben/zstd/ZstdDecompressCtx.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDecompressCtx.java
@@ -12,7 +12,8 @@ public class ZstdDecompressCtx extends AutoCloseBase {
         Native.load();
     }
 
-    private MemoryAddress nativePtr = 0;
+    private MemoryAddress nativePtr = null;
+
     private ZstdDictDecompress decompression_dict = null;
 
     private static native MemoryAddress init();

--- a/src/main/java/com/github/luben/zstd/ZstdDictCompress.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDictCompress.java
@@ -9,7 +9,7 @@ public class ZstdDictCompress extends SharedDictBase {
         Native.load();
     }
 
-    private long nativePtr = 0;
+    private MemoryAddress nativePtr = null;
     private int level = Zstd.defaultCompressionLevel();
 
     private native void init(byte[] dict, int dict_offset, int dict_size, int level);
@@ -44,7 +44,7 @@ public class ZstdDictCompress extends SharedDictBase {
 
         init(dict, offset, length, level);
 
-        if (0 == nativePtr) {
+        if (MemoryAddress.isNull(nativePtr)) {
             throw new IllegalStateException("ZSTD_createCDict failed");
         }
         // Ensures that even if ZstdDictCompress is created and published through a race, no thread could observe
@@ -69,7 +69,7 @@ public class ZstdDictCompress extends SharedDictBase {
         }
 	initDirect(dict, dict.position(), length, level);
 
-        if (nativePtr == 0L) {
+        if (MemoryAddress.isNull(nativePtr)) {
            throw new IllegalStateException("ZSTD_createCDict failed");
         }
         // Ensures that even if ZstdDictCompress is created and published through a race, no thread could observe
@@ -84,9 +84,9 @@ public class ZstdDictCompress extends SharedDictBase {
 
     @Override
     void  doClose() {
-        if (nativePtr != 0) {
+        if (!MemoryAddress.isNull(nativePtr)) {
             free();
-            nativePtr = 0;
+            nativePtr = null;
         }
     }
 }

--- a/src/main/java/com/github/luben/zstd/ZstdDictDecompress.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDictDecompress.java
@@ -9,7 +9,7 @@ public class ZstdDictDecompress extends SharedDictBase {
         Native.load();
     }
 
-    private long nativePtr = 0L;
+    private MemoryAddress nativePtr = null;
 
     private native void init(byte[] dict, int dict_offset, int dict_size);
 
@@ -73,9 +73,9 @@ public class ZstdDictDecompress extends SharedDictBase {
 
     @Override
      void doClose() {
-        if (nativePtr != 0) {
+        if (!MemoryAddress.isNull(nativePtr)) {
             free();
-            nativePtr = 0;
+            nativePtr = null;
         }
     }
 }

--- a/src/main/java/com/github/luben/zstd/ZstdDictDecompress.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDictDecompress.java
@@ -37,11 +37,11 @@ public class ZstdDictDecompress extends SharedDictBase {
 
         init(dict, offset, length);
 
-        if (nativePtr == 0L) {
+        if (MemoryAddress.isNull(nativePtr)) {
            throw new IllegalStateException("ZSTD_createDDict failed");
         }
         // Ensures that even if ZstdDictDecompress is created and published through a race, no thread could observe
-        // nativePtr == 0.
+        // nativePtr == null.
         storeFence();
     }
 
@@ -62,7 +62,7 @@ public class ZstdDictDecompress extends SharedDictBase {
         }
 	initDirect(dict, dict.position(), length);
 
-        if (nativePtr == 0L) {
+        if (MemoryAddress.isNull(nativePtr)) {
            throw new IllegalStateException("ZSTD_createDDict failed");
         }
         // Ensures that even if ZstdDictDecompress is created and published through a race, no thread could observe

--- a/src/main/java/com/github/luben/zstd/ZstdDirectBufferCompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDirectBufferCompressingStreamNoFinalizer.java
@@ -14,7 +14,7 @@ public class ZstdDirectBufferCompressingStreamNoFinalizer implements Closeable, 
     }
 
     private ByteBuffer target;
-    private final long stream;
+    private final MemoryAddress stream;
 
     /**
      * This method should flush the buffer and either return the same buffer (but cleared) or a new buffer
@@ -47,14 +47,14 @@ public class ZstdDirectBufferCompressingStreamNoFinalizer implements Closeable, 
 
     /* JNI methods */
     private static native long recommendedCOutSize();
-    private static native long createCStream();
-    private static native long  freeCStream(long ctx);
-    private native long initCStream(long ctx, int level);
-    private native long initCStreamWithDict(long ctx, byte[] dict, int dict_size, int level);
-    private native long initCStreamWithFastDict(long ctx, ZstdDictCompress dict);
-    private native long compressDirectByteBuffer(long ctx, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
-    private native long flushStream(long ctx, ByteBuffer dst, int dstOffset, int dstSize);
-    private native long endStream(long ctx, ByteBuffer dst, int dstOffset, int dstSize);
+    private static native MemoryAddress createCStream();
+    private static native long  freeCStream(MemoryAddress ctx);
+    private native long initCStream(MemoryAddress ctx, int level);
+    private native long initCStreamWithDict(MemoryAddress ctx, byte[] dict, int dict_size, int level);
+    private native long initCStreamWithFastDict(MemoryAddress ctx, ZstdDictCompress dict);
+    private native long compressDirectByteBuffer(MemoryAddress ctx, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
+    private native long flushStream(MemoryAddress ctx, ByteBuffer dst, int dstOffset, int dstSize);
+    private native long endStream(MemoryAddress ctx, ByteBuffer dst, int dstOffset, int dstSize);
 
     public ZstdDirectBufferCompressingStreamNoFinalizer setDict(byte[] dict) {
         if (initialized) {

--- a/src/main/java/com/github/luben/zstd/ZstdDirectBufferDecompressingStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdDirectBufferDecompressingStreamNoFinalizer.java
@@ -29,22 +29,22 @@ public class ZstdDirectBufferDecompressingStreamNoFinalizer extends BaseZstdBuff
     }
 
     @Override
-    long createDStream() {
+    MemoryAddress createDStream() {
         return createDStreamNative();
     }
 
     @Override
-    long freeDStream(long stream) {
+    long freeDStream(MemoryAddress stream) {
         return freeDStreamNative(stream);
     }
 
     @Override
-    long initDStream(long stream) {
+    long initDStream(MemoryAddress stream) {
         return initDStreamNative(stream);
     }
 
     @Override
-    long decompressStream(long stream, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize) {
+    long decompressStream(MemoryAddress stream, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize) {
         return decompressStreamNative(stream, dst, dstOffset, dstSize, src, srcOffset, srcSize);
     }
 
@@ -52,13 +52,13 @@ public class ZstdDirectBufferDecompressingStreamNoFinalizer extends BaseZstdBuff
         return (int) recommendedDOutSizeNative();
     }
 
-    private static native long createDStreamNative();
+    private static native MemoryAddress createDStreamNative();
 
-    private static native long freeDStreamNative(long stream);
+    private static native long freeDStreamNative(MemoryAddress stream);
 
-    private native long initDStreamNative(long stream);
+    private native long initDStreamNative(MemoryAddress stream);
 
-    private native long decompressStreamNative(long stream, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
+    private native long decompressStreamNative(MemoryAddress stream, ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize);
 
     private static native long recommendedDOutSizeNative();
 }

--- a/src/main/java/com/github/luben/zstd/ZstdInputStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdInputStreamNoFinalizer.java
@@ -24,7 +24,7 @@ public class ZstdInputStreamNoFinalizer extends FilterInputStream {
     }
 
     // Opaque pointer to Zstd context object
-    private final long stream;
+    private final MemoryAddress stream;
     private long dstPos = 0;
     private long srcPos = 0;
     private long srcSize = 0;
@@ -41,10 +41,10 @@ public class ZstdInputStreamNoFinalizer extends FilterInputStream {
     /* JNI methods */
     public static native long recommendedDInSize();
     public static native long recommendedDOutSize();
-    private static native long createDStream();
-    private static native int  freeDStream(long stream);
-    private native int  initDStream(long stream);
-    private native int  decompressStream(long stream, byte[] dst, int dst_size, byte[] src, int src_size);
+    private static native MemoryAddress createDStream();
+    private static native int  freeDStream(MemoryAddress stream);
+    private native int  initDStream(MemoryAddress stream);
+    private native int  decompressStream(MemoryAddress stream, byte[] dst, int dst_size, byte[] src, int src_size);
 
     /**
      * create a new decompressing InputStream

--- a/src/main/java/com/github/luben/zstd/ZstdOutputStreamNoFinalizer.java
+++ b/src/main/java/com/github/luben/zstd/ZstdOutputStreamNoFinalizer.java
@@ -19,7 +19,7 @@ public class ZstdOutputStreamNoFinalizer extends FilterOutputStream {
     }
 
     /* Opaque pointer to Zstd context object */
-    private final long stream;
+    private final MemoryAddress stream;
     // Source and Destination positions
     private long srcPos = 0;
     private long dstPos = 0;
@@ -34,12 +34,12 @@ public class ZstdOutputStreamNoFinalizer extends FilterOutputStream {
 
     /* JNI methods */
     public static native long recommendedCOutSize();
-    private static native long createCStream();
-    private static native int  freeCStream(long ctx);
-    private native int resetCStream(long ctx);
-    private native int compressStream(long ctx, byte[] dst, int dst_size, byte[] src, int src_size);
-    private native int flushStream(long ctx, byte[] dst, int dst_size);
-    private native int endStream(long ctx, byte[] dst, int dst_size);
+    private static native MemoryAddress createCStream();
+    private static native int  freeCStream(MemoryAddress ctx);
+    private native int resetCStream(MemoryAddress ctx);
+    private native int compressStream(MemoryAddress ctx, byte[] dst, int dst_size, byte[] src, int src_size);
+    private native int flushStream(MemoryAddress ctx, byte[] dst, int dst_size);
+    private native int endStream(MemoryAddress ctx, byte[] dst, int dst_size);
 
 
     /**

--- a/src/main/java/com/github/luben/zstd/util/Native.java
+++ b/src/main/java/com/github/luben/zstd/util/Native.java
@@ -166,7 +166,6 @@ public enum Native {
             loaded = true;
         } catch (IOException e) {
             // IO errors in extracting and writing the shared object in the temp dir
-            System.out.println(">>>>>>>>>>>>>>>> HERE HERE HERE HERE HERE HERE\n");
             ExceptionInInitializerError err = new ExceptionInInitializerError(
                     "Cannot unpack " + libname + ": " + e.getMessage());
             err.setStackTrace(e.getStackTrace());

--- a/src/main/java/com/github/luben/zstd/util/Native.java
+++ b/src/main/java/com/github/luben/zstd/util/Native.java
@@ -166,6 +166,7 @@ public enum Native {
             loaded = true;
         } catch (IOException e) {
             // IO errors in extracting and writing the shared object in the temp dir
+            System.out.println(">>>>>>>>>>>>>>>> HERE HERE HERE HERE HERE HERE\n");
             ExceptionInInitializerError err = new ExceptionInInitializerError(
                     "Cannot unpack " + libname + ": " + e.getMessage());
             err.setStackTrace(e.getStackTrace());

--- a/src/main/native/jni_bufferdecompress_zstd.c
+++ b/src/main/native/jni_bufferdecompress_zstd.c
@@ -33,7 +33,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStream
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer_freeDStreamNative
-  (JNIEnv *env, jclass obj, jlong stream) {
+  (JNIEnv *env, jclass obj, jobject stream) {
     return ZSTD_freeDCtx((ZSTD_DCtx *)(intptr_t) stream);
 }
 
@@ -43,7 +43,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStream
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer_initDStreamNative
-  (JNIEnv *env, jclass obj, jlong stream) {
+  (JNIEnv *env, jclass obj, jobject stream) {
     jclass clazz = (*env)->GetObjectClass(env, obj);
     consumed_id = (*env)->GetFieldID(env, clazz, "consumed", "I");
     produced_id = (*env)->GetFieldID(env, clazz, "produced", "I");
@@ -56,7 +56,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStream
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)I
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer_decompressStreamNative
-  (JNIEnv *env, jclass obj, jlong stream, jbyteArray dst, jint dst_offset, jint dst_size, jbyteArray src, jint src_offset, jint src_size) {
+  (JNIEnv *env, jclass obj, jobject stream, jbyteArray dst, jint dst_offset, jint dst_size, jbyteArray src, jint src_offset, jint src_size) {
     // input validation
     if (NULL == dst) return -ZSTD_error_dstSize_tooSmall;
     if (NULL == src) return -ZSTD_error_srcSize_wrong;

--- a/src/main/native/jni_bufferdecompress_zstd.c
+++ b/src/main/native/jni_bufferdecompress_zstd.c
@@ -22,9 +22,9 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStream
  * Method:    createDStreamNative
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer_createDStreamNative
+JNIEXPORT jobject JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer_createDStreamNative
   (JNIEnv *env, jclass obj) {
-    return (jlong)(intptr_t) ZSTD_createDStream();
+    return (*env)->NewMemoryAddress(env, ZSTD_createDStream());
 }
 
 /*
@@ -34,7 +34,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStream
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStreamNoFinalizer_freeDStreamNative
   (JNIEnv *env, jclass obj, jobject stream) {
-    return ZSTD_freeDCtx((ZSTD_DCtx *)(intptr_t) stream);
+    return ZSTD_freeDCtx((ZSTD_DCtx *)(*env)->GetMemoryAddress(env, stream));
 }
 
 /*
@@ -47,7 +47,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStream
     jclass clazz = (*env)->GetObjectClass(env, obj);
     consumed_id = (*env)->GetFieldID(env, clazz, "consumed", "I");
     produced_id = (*env)->GetFieldID(env, clazz, "produced", "I");
-    return ZSTD_initDStream((ZSTD_DCtx *)(intptr_t) stream);
+    return ZSTD_initDStream((ZSTD_DCtx *)(*env)->GetMemoryAddress(env, stream));
 }
 
 /*
@@ -76,7 +76,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdBufferDecompressingStream
     ZSTD_outBuffer output = { dst_buf_ptr + dst_offset, dst_size, 0};
     ZSTD_inBuffer input = { src_buf_ptr + src_offset, src_size, 0};
 
-    size = ZSTD_decompressStream((ZSTD_DCtx *)(intptr_t) stream, &output, &input);
+    size = ZSTD_decompressStream((ZSTD_DCtx *)(*env)->GetMemoryAddress(env, stream), &output, &input);
 
     (*env)->ReleasePrimitiveArrayCritical(env, src, src_buf_ptr, JNI_ABORT);
 E2: (*env)->ReleasePrimitiveArrayCritical(env, dst, dst_buf_ptr, 0);

--- a/src/main/native/jni_directbuffercompress_zstd.c
+++ b/src/main/native/jni_directbuffercompress_zstd.c
@@ -83,8 +83,8 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingSt
     consumed_id = (*env)->GetFieldID(env, clazz, "consumed", "I");
     produced_id = (*env)->GetFieldID(env, clazz, "produced", "I");
     jclass dict_clazz = (*env)->GetObjectClass(env, dict);
-    jfieldID compress_dict = (*env)->GetFieldID(env, dict_clazz, "nativePtr", "J");
-    ZSTD_CDict* cdict = (ZSTD_CDict*)(*env)->GetMemoryAddress(env, (*env)->GetObjectField(env, obj, compress_dict));
+    jfieldID compress_dict = (*env)->GetFieldID(env, dict_clazz, "nativePtr", "Ljava/lang/MemoryAddress;");
+    ZSTD_CDict* cdict = (ZSTD_CDict*)(*env)->GetMemoryAddress(env, (*env)->GetObjectField(env, dict, compress_dict));
     if (cdict == NULL) return -ZSTD_error_dictionary_wrong;
     ZSTD_CStream *stream_pointer = (ZSTD_CStream *)(*env)->GetMemoryAddress(env, stream);
     ZSTD_CCtx_reset(stream_pointer, ZSTD_reset_session_only);

--- a/src/main/native/jni_directbuffercompress_zstd.c
+++ b/src/main/native/jni_directbuffercompress_zstd.c
@@ -34,7 +34,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingSt
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_freeCStream
-  (JNIEnv *env, jclass obj, jlong stream) {
+  (JNIEnv *env, jclass obj, jobject stream) {
     return ZSTD_freeCStream((ZSTD_CStream *)(intptr_t) stream);
 }
 
@@ -44,7 +44,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingSt
  * Signature: (JI)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_initCStream
-  (JNIEnv *env, jclass obj, jlong stream, jint level) {
+  (JNIEnv *env, jclass obj, jobject stream, jint level) {
     jclass clazz = (*env)->GetObjectClass(env, obj);
     consumed_id = (*env)->GetFieldID(env, clazz, "consumed", "I");
     produced_id = (*env)->GetFieldID(env, clazz, "produced", "I");
@@ -57,7 +57,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingSt
  * Signature: (J[BII)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_initCStreamWithDict
-  (JNIEnv *env, jclass obj, jlong stream, jbyteArray dict, jint dict_size, jint level) {
+  (JNIEnv *env, jclass obj, jobject stream, jbyteArray dict, jint dict_size, jint level) {
     size_t result = -ZSTD_error_memory_allocation;
     jclass clazz = (*env)->GetObjectClass(env, obj);
     consumed_id = (*env)->GetFieldID(env, clazz, "consumed", "I");
@@ -77,15 +77,15 @@ E1:
  * Method:    initCStreamWithFastDict
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_initCStreamWithFastDict
-  (JNIEnv *env, jclass obj, jlong stream, jobject dict) {
+  (JNIEnv *env, jclass obj, jobject stream, jobject dict) {
     jclass clazz = (*env)->GetObjectClass(env, obj);
     consumed_id = (*env)->GetFieldID(env, clazz, "consumed", "I");
     produced_id = (*env)->GetFieldID(env, clazz, "produced", "I");
     jclass dict_clazz = (*env)->GetObjectClass(env, dict);
     jfieldID compress_dict = (*env)->GetFieldID(env, dict_clazz, "nativePtr", "J");
-    ZSTD_CDict* cdict = (ZSTD_CDict*)(intptr_t)(*env)->GetLongField(env, dict, compress_dict);
+    ZSTD_CDict* cdict = (ZSTD_CDict*)(*env)->GetMemoryAddress(env, (*env)->GetObjectField(env, obj, compress_dict));
     if (cdict == NULL) return -ZSTD_error_dictionary_wrong;
-    ZSTD_CCtx_reset((ZSTD_CStream *)(intptr_t) stream, ZSTD_reset_session_only);
+    ZSTD_CCtx_reset((ZSTD_CStream *)(*env)->GetMemoryAddress(env, stream), ZSTD_reset_session_only);
     return ZSTD_CCtx_refCDict((ZSTD_CStream *)(intptr_t) stream, cdict);
 }
 
@@ -95,22 +95,22 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingSt
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_compressDirectByteBuffer
-  (JNIEnv *env, jclass obj, jlong stream, jobject dst_buf, jint dst_offset, jint dst_size, jobject src_buf, jint src_offset, jint src_size) {
+  (JNIEnv *env, jclass obj, jobject stream, jobject dst_buf, jint dst_offset, jint dst_size, jobject src_buf, jint src_offset, jint src_size) {
 
     size_t size = -ZSTD_error_memory_allocation;
     jsize dst_cap = (*env)->GetDirectBufferCapacity(env, dst_buf);
     if (dst_offset + dst_size > dst_cap) return -ZSTD_error_dstSize_tooSmall;
     jsize src_cap = (*env)->GetDirectBufferCapacity(env, src_buf);
     if (src_offset + src_size > src_cap) return -ZSTD_error_srcSize_wrong;
-    char *dst_buf_ptr = (char*)(*env)->GetDirectBufferAddress(env, dst_buf);
+    char *dst_buf_ptr = (char*)(*env)->GetDirectBufferPointer(env, dst_buf);
     if (dst_buf_ptr == NULL) goto E1;
-    char *src_buf_ptr = (char*)(*env)->GetDirectBufferAddress(env, src_buf);
+    char *src_buf_ptr = (char*)(*env)->GetDirectBufferPointer(env, src_buf);
     if (src_buf_ptr == NULL) goto E1;
 
     ZSTD_outBuffer output = { dst_buf_ptr + dst_offset, dst_size, 0 };
     ZSTD_inBuffer input = { src_buf_ptr + src_offset, src_size, 0 };
 
-    size = ZSTD_compressStream((ZSTD_CStream *)(intptr_t) stream, &output, &input);
+    size = ZSTD_compressStream((ZSTD_CStream *)(*env)->GetMemoryAddress(env, stream), &output, &input);
 
     (*env)->SetIntField(env, obj, consumed_id, input.pos);
     (*env)->SetIntField(env, obj, produced_id, output.pos);
@@ -123,17 +123,17 @@ E1: return size;
  * Signature: (JLjava/nio/ByteBuffer;II)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_endStream
-  (JNIEnv *env, jclass obj, jlong stream, jobject dst_buf, jint dst_offset, jint dst_size) {
+  (JNIEnv *env, jclass obj, jobject stream, jobject dst_buf, jint dst_offset, jint dst_size) {
 
     size_t size = -ZSTD_error_memory_allocation;
 
     jsize dst_cap = (*env)->GetDirectBufferCapacity(env, dst_buf);
     if (dst_offset + dst_size > dst_cap) return -ZSTD_error_dstSize_tooSmall;
-    char *dst_buf_ptr = (char*)(*env)->GetDirectBufferAddress(env, dst_buf);
+    char *dst_buf_ptr = (char*)(*env)->GetDirectBufferPointer(env, dst_buf);
 
     if (dst_buf_ptr != NULL) {
         ZSTD_outBuffer output = { dst_buf_ptr + dst_offset, dst_size, 0 };
-        size = ZSTD_endStream((ZSTD_CStream *)(intptr_t) stream, &output);
+        size = ZSTD_endStream((ZSTD_CStream *)(*env)->GetMemoryAddress(env, stream), &output);
         (*env)->SetIntField(env, obj, produced_id, output.pos);
     }
     return size;
@@ -145,16 +145,16 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingSt
  * Signature: (JLjava/nio/ByteBuffer;II)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferCompressingStreamNoFinalizer_flushStream
-  (JNIEnv *env, jclass obj, jlong stream, jobject dst_buf, jint dst_offset, jint dst_size) {
+  (JNIEnv *env, jclass obj, jobject stream, jobject dst_buf, jint dst_offset, jint dst_size) {
 
     size_t size = -ZSTD_error_memory_allocation;
 
     jsize dst_cap = (*env)->GetDirectBufferCapacity(env, dst_buf);
     if (dst_offset + dst_size > dst_cap) return -ZSTD_error_dstSize_tooSmall;
-    char *dst_buf_ptr = (char*)(*env)->GetDirectBufferAddress(env, dst_buf);
+    char *dst_buf_ptr = (char*)(*env)->GetDirectBufferPointer(env, dst_buf);
     if (dst_buf_ptr != NULL) {
         ZSTD_outBuffer output = { dst_buf_ptr + dst_offset, dst_size, 0 };
-        size = ZSTD_flushStream((ZSTD_CStream *)(intptr_t) stream, &output);
+        size = ZSTD_flushStream((ZSTD_CStream *)(*env)->GetMemoryAddress(env, stream), &output);
         (*env)->SetIntField(env, obj, produced_id, output.pos);
     }
     return size;

--- a/src/main/native/jni_directbufferdecompress_zstd.c
+++ b/src/main/native/jni_directbufferdecompress_zstd.c
@@ -22,9 +22,9 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressing
  * Method:    createDStreamNative
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_createDStreamNative
+JNIEXPORT jobject JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_createDStreamNative
   (JNIEnv *env, jclass obj) {
-    return (jlong)(intptr_t) ZSTD_createDStream();
+    return (*env)->NewMemoryAddress(env, ZSTD_createDStream());
 }
 
 /*
@@ -34,7 +34,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressing
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_freeDStreamNative
   (JNIEnv *env, jclass obj, jobject stream) {
-    return ZSTD_freeDCtx((ZSTD_DCtx *)(intptr_t) stream);
+    return ZSTD_freeDCtx((ZSTD_DCtx *)(*env)->GetMemoryAddress(env, stream));
 }
 
 /*
@@ -47,7 +47,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressing
     jclass clazz = (*env)->GetObjectClass(env, obj);
     consumed_id = (*env)->GetFieldID(env, clazz, "consumed", "I");
     produced_id = (*env)->GetFieldID(env, clazz, "produced", "I");
-    return ZSTD_initDStream((ZSTD_DCtx *)(intptr_t) stream);
+    return ZSTD_initDStream((ZSTD_DCtx *)(*env)->GetMemoryAddress(env, stream));
 }
 
 /*
@@ -71,7 +71,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressing
     ZSTD_outBuffer output = { dst_buf_ptr + dst_offset, dst_size, 0};
     ZSTD_inBuffer input = { src_buf_ptr + src_offset, src_size, 0 };
 
-    size = ZSTD_decompressStream((ZSTD_DCtx *)(intptr_t) stream, &output, &input);
+    size = ZSTD_decompressStream((ZSTD_DCtx *)(*env)->GetMemoryAddress(env, stream), &output, &input);
 
     (*env)->SetIntField(env, obj, consumed_id, input.pos);
     (*env)->SetIntField(env, obj, produced_id, output.pos);

--- a/src/main/native/jni_directbufferdecompress_zstd.c
+++ b/src/main/native/jni_directbufferdecompress_zstd.c
@@ -33,7 +33,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressing
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_freeDStreamNative
-  (JNIEnv *env, jclass obj, jlong stream) {
+  (JNIEnv *env, jclass obj, jobject stream) {
     return ZSTD_freeDCtx((ZSTD_DCtx *)(intptr_t) stream);
 }
 
@@ -43,7 +43,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressing
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_initDStreamNative
-  (JNIEnv *env, jclass obj, jlong stream) {
+  (JNIEnv *env, jclass obj, jobject stream) {
     jclass clazz = (*env)->GetObjectClass(env, obj);
     consumed_id = (*env)->GetFieldID(env, clazz, "consumed", "I");
     produced_id = (*env)->GetFieldID(env, clazz, "produced", "I");
@@ -56,7 +56,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressing
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)I
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDirectBufferDecompressingStreamNoFinalizer_decompressStreamNative
-  (JNIEnv *env, jclass obj, jlong stream, jobject dst_buf, jint dst_offset, jint dst_size, jobject src_buf, jint src_offset, jint src_size) {
+  (JNIEnv *env, jclass obj, jobject stream, jobject dst_buf, jint dst_offset, jint dst_size, jobject src_buf, jint src_offset, jint src_size) {
     size_t size = -ZSTD_error_memory_allocation;
 
     jsize dst_cap = (*env)->GetDirectBufferCapacity(env, dst_buf);

--- a/src/main/native/jni_fast_zstd.c
+++ b/src/main/native/jni_fast_zstd.c
@@ -240,11 +240,11 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_Zstd_decompressDirectByteBuff
  * Method:    init
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_init
+JNIEXPORT jobject JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_init
   (JNIEnv *env, jclass clazz)
 {
     ZSTD_CCtx* cctx = ZSTD_createCCtx();
-    return (jlong)(intptr_t) cctx;
+    return (*env)->NewMemoryAddress(env, cctx);
 }
 
 /*
@@ -495,11 +495,11 @@ E1: return size;
  * Method:    init
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_init
+JNIEXPORT jobject JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_init
   (JNIEnv *env, jclass clazz)
 {
     ZSTD_DCtx* dctx = ZSTD_createDCtx();
-    return (jlong)(intptr_t) dctx;
+    return (*env)->NewMemoryAddress(env, dctx);
 }
 
 /*

--- a/src/main/native/jni_fast_zstd.c
+++ b/src/main/native/jni_fast_zstd.c
@@ -19,14 +19,14 @@ JNIEXPORT void JNICALL Java_com_github_luben_zstd_ZstdDictCompress_init
   (JNIEnv *env, jobject obj, jbyteArray dict, jint dict_offset, jint dict_size, jint level)
 {
     jclass clazz = (*env)->GetObjectClass(env, obj);
-    compress_dict = (*env)->GetFieldID(env, clazz, "nativePtr", "Ljava/lang/MemoryAddress");
+    compress_dict = (*env)->GetFieldID(env, clazz, "nativePtr", "Ljava/lang/MemoryAddress;");
     if (NULL == dict) return;
     void *dict_buff = (*env)->GetPrimitiveArrayCritical(env, dict, NULL);
     if (NULL == dict_buff) return;
     ZSTD_CDict* cdict = ZSTD_createCDict(((char *)dict_buff) + dict_offset, dict_size, level);
     (*env)->ReleasePrimitiveArrayCritical(env, dict, dict_buff, JNI_ABORT);
     if (NULL == cdict) return;
-    (*env)->SetObjectField(env, obj, compress_dict, (*env)->NewMemoryAddress(cdict));
+    (*env)->SetObjectField(env, obj, compress_dict, (*env)->NewMemoryAddress(env, cdict));
 }
 
 /*
@@ -38,13 +38,13 @@ JNIEXPORT void JNICALL Java_com_github_luben_zstd_ZstdDictCompress_initDirect
   (JNIEnv *env, jobject obj, jobject dict, jint dict_offset, jint dict_size, jint level)
 {
     jclass clazz = (*env)->GetObjectClass(env, obj);
-    compress_dict = (*env)->GetFieldID(env, clazz, "nativePtr", "Ljava/lang/MemoryAddress");
+    compress_dict = (*env)->GetFieldID(env, clazz, "nativePtr", "Ljava/lang/MemoryAddress;");
     if (NULL == dict) return;
     void *dict_buff = (*env)->GetDirectBufferPointer(env, dict);
     if (NULL == dict_buff) return;
     ZSTD_CDict* cdict = ZSTD_createCDict(((char *)dict_buff) + dict_offset, dict_size, level);
     if (NULL == cdict) return;
-    (*env)->SetObjectField(env, obj, compress_dict, (*env)->NewMemoryAddress(cdict));
+    (*env)->SetObjectField(env, obj, compress_dict, (*env)->NewMemoryAddress(env, cdict));
 }
 
 /*
@@ -79,7 +79,7 @@ JNIEXPORT void JNICALL Java_com_github_luben_zstd_ZstdDictDecompress_init
 
     (*env)->ReleasePrimitiveArrayCritical(env, dict, dict_buff, JNI_ABORT);
     if (NULL == ddict) return;
-    (*env)->SetObjectField(env, obj, decompress_dict, (*env)->NewMemoryAddress(ddict));
+    (*env)->SetObjectField(env, obj, decompress_dict, (*env)->NewMemoryAddress(env, ddict));
 }
 
 /*
@@ -98,7 +98,7 @@ JNIEXPORT void JNICALL Java_com_github_luben_zstd_ZstdDictDecompress_initDirect
     ZSTD_DDict* ddict = ZSTD_createDDict(((char *)dict_buff) + dict_offset, dict_size);
 
     if (NULL == ddict) return;
-    (*env)->SetObjectField(env, obj, decompress_dict, (*env)->NewMemoryAddress(ddict));
+    (*env)->SetObjectField(env, obj, decompress_dict, (*env)->NewMemoryAddress(env, ddict));
 }
 
 /*
@@ -320,7 +320,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_loadCDictFast
         // remove dictionary
         return ZSTD_CCtx_refCDict(cctx, NULL);
     }
-    ZSTD_CDict* cdict = (ZSTD_CDict*)(intptr_t)(*env)->GetLongField(env, dict, compress_dict);
+    ZSTD_CDict* cdict = (ZSTD_CDict*)(*env)->GetMemoryAddress(env, (*env)->GetObjectField(env, dict, compress_dict));
     if (NULL == cdict) return -ZSTD_error_dictionary_wrong;
     return ZSTD_CCtx_refCDict(cctx, cdict);
 }
@@ -331,9 +331,9 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_loadCDictFast
  * Signature: (J[B)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_loadCDict0
-  (JNIEnv *env, jclass clazz, jlong ptr, jbyteArray dict)
+  (JNIEnv *env, jclass clazz, jobject ptr, jbyteArray dict)
 {
-    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(intptr_t) ptr;
+    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(*env)->GetMemoryAddress(env, ptr);
     if (dict == NULL) {
         // remove dictionary
         return ZSTD_CCtx_loadDictionary(cctx, NULL, 0);
@@ -352,14 +352,14 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_loadCDict0
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_reset0
-  (JNIEnv *env, jclass jctx, jlong ptr) {
-    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(intptr_t) ptr;
+  (JNIEnv *env, jclass jctx, jobject ptr) {
+    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(*env)->GetMemoryAddress(env, ptr);
     return ZSTD_CCtx_reset(cctx, ZSTD_reset_session_and_parameters);
 }
 
 JNIEXPORT jobject JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_getFrameProgression0
-  (JNIEnv *env, jclass jctx, jlong ptr) {
-    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(intptr_t) ptr;
+  (JNIEnv *env, jclass jctx, jobject ptr) {
+    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(*env)->GetMemoryAddress(env, ptr);
     ZSTD_frameProgression native_progression = ZSTD_getFrameProgression(cctx);
 
     jclass frame_progression_class = (*env)->FindClass(env, "com/github/luben/zstd/ZstdFrameProgression");
@@ -371,16 +371,16 @@ JNIEXPORT jobject JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_getFramePro
 }
 
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_setPledgedSrcSize0
-  (JNIEnv *env, jclass jctx, jlong ptr, jlong src_size) {
+  (JNIEnv *env, jclass jctx, jobject ptr, jlong src_size) {
     if (src_size < 0) {
         return -ZSTD_error_srcSize_wrong;
     }
-    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(intptr_t) ptr;
+    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(*env)->GetMemoryAddress(env, ptr);
     return ZSTD_CCtx_setPledgedSrcSize(cctx, (unsigned long long)src_size);
 }
 
 static size_t compress_direct_buffer_stream
-  (JNIEnv *env, jclass jctx, jlong ptr, jobject dst, jint *dst_offset, jint dst_size, jobject src, jint *src_offset, jint src_size, jint end_op) {
+  (JNIEnv *env, jclass jctx, jobject ptr, jobject dst, jint *dst_offset, jint dst_size, jobject src, jint *src_offset, jint src_size, jint end_op) {
     if (NULL == dst) return -ZSTD_error_dstSize_tooSmall;
     if (NULL == src) return -ZSTD_error_srcSize_wrong;
     if (0 > *dst_offset) return -ZSTD_error_dstSize_tooSmall;
@@ -391,7 +391,7 @@ static size_t compress_direct_buffer_stream
     if (dst_size > dst_cap) return -ZSTD_error_dstSize_tooSmall;
     jsize src_cap = (*env)->GetDirectBufferCapacity(env, src);
     if (src_size > src_cap) return -ZSTD_error_srcSize_wrong;
-    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(intptr_t) ptr;
+    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(*env)->GetMemoryAddress(env, ptr);
 
     ZSTD_outBuffer out;
     out.pos = *dst_offset;
@@ -416,7 +416,7 @@ static size_t compress_direct_buffer_stream
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;III)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_compressDirectByteBufferStream0
-  (JNIEnv *env, jclass jctx, jlong ptr, jobject dst, jint dst_offset, jint dst_size, jobject src, jint src_offset, jint src_size, jint end_op) {
+  (JNIEnv *env, jclass jctx, jobject ptr, jobject dst, jint dst_offset, jint dst_size, jobject src, jint src_offset, jint src_size, jint end_op) {
     size_t result = compress_direct_buffer_stream(env, jctx, ptr, dst, &dst_offset, dst_size, src, &src_offset, src_size, end_op);
     if (ZSTD_isError(result)) {
         return (1ULL << 31) | ZSTD_getErrorCode(result);
@@ -434,7 +434,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_compressDirec
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_compressDirectByteBuffer0
-  (JNIEnv *env, jclass jctx, jlong ptr, jobject dst, jint dst_offset, jint dst_size, jobject src, jint src_offset, jint src_size) {
+  (JNIEnv *env, jclass jctx, jobject ptr, jobject dst, jint dst_offset, jint dst_size, jobject src, jint src_offset, jint src_size) {
     if (NULL == dst) return -ZSTD_error_dstSize_tooSmall;
     if (NULL == src) return -ZSTD_error_srcSize_wrong;
     if (0 > dst_offset) return -ZSTD_error_dstSize_tooSmall;
@@ -446,7 +446,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_compressDirec
     jsize src_cap = (*env)->GetDirectBufferCapacity(env, src);
     if (src_offset + src_size > src_cap) return -ZSTD_error_srcSize_wrong;
 
-    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(intptr_t) ptr;
+    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(*env)->GetMemoryAddress(env, ptr);
 
     char *dst_buff = (char*)(*env)->GetDirectBufferAddress(env, dst);
     if (dst_buff == NULL) return -ZSTD_error_memory_allocation;
@@ -463,7 +463,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_compressDirec
  * Signature: (JB[IIB[II)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_compressByteArray0
-  (JNIEnv *env, jclass jctx, jlong ptr, jbyteArray dst, jint dst_offset, jint dst_size, jbyteArray src, jint src_offset, jint src_size) {
+  (JNIEnv *env, jclass jctx, jobject ptr, jbyteArray dst, jint dst_offset, jint dst_size, jbyteArray src, jint src_offset, jint src_size) {
     size_t size = -ZSTD_error_memory_allocation;
 
     if (0 > dst_offset) return -ZSTD_error_dstSize_tooSmall;
@@ -473,7 +473,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdCompressCtx_compressByteA
     if (src_offset + src_size > (*env)->GetArrayLength(env, src)) return -ZSTD_error_srcSize_wrong;
     if (dst_offset + dst_size > (*env)->GetArrayLength(env, dst)) return -ZSTD_error_dstSize_tooSmall;
 
-    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(intptr_t) ptr;
+    ZSTD_CCtx* cctx = (ZSTD_CCtx*)(*env)->GetMemoryAddress(env, ptr);
 
     void *dst_buff = (*env)->GetPrimitiveArrayCritical(env, dst, NULL);
     if (dst_buff == NULL) goto E1;
@@ -508,9 +508,9 @@ JNIEXPORT jobject JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_init
  * Signature: ()V
  */
 JNIEXPORT void JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_free
-  (JNIEnv *env, jclass clazz, jlong ptr)
+  (JNIEnv *env, jclass clazz, jobject ptr)
 {
-    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(intptr_t)ptr;
+    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(*env)->GetMemoryAddress(env, ptr);
     if (NULL == dctx) return;
     ZSTD_freeDCtx(dctx);
 }
@@ -521,14 +521,14 @@ JNIEXPORT void JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_free
  * Signature: (JLcom/github/luben/zstd/ZstdDictDecompress;)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_loadDDictFast0
-  (JNIEnv *env, jclass clazz, jlong ptr, jobject dict)
+  (JNIEnv *env, jclass clazz, jobject ptr, jobject dict)
 {
-    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(intptr_t)ptr;
+    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(*env)->GetMemoryAddress(env, ptr);
     if (dict == NULL) {
         // remove dictionary
         return ZSTD_DCtx_refDDict(dctx, NULL);
     }
-    ZSTD_DDict* ddict = (ZSTD_DDict*)(intptr_t)(*env)->GetLongField(env, dict, decompress_dict);
+    ZSTD_DDict* ddict = (ZSTD_DDict*)(*env)->GetMemoryAddress(env, (*env)->GetObjectField(env, dict, decompress_dict));
     if (NULL == ddict) return -ZSTD_error_dictionary_wrong;
     return ZSTD_DCtx_refDDict(dctx, ddict);
 }
@@ -539,9 +539,9 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_loadDDictFa
  * Signature: (J[B)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_loadDDict0
-  (JNIEnv *env, jclass clazz, jlong ptr, jbyteArray dict)
+  (JNIEnv *env, jclass clazz, jobject ptr, jbyteArray dict)
 {
-    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(intptr_t)ptr;
+    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(*env)->GetMemoryAddress(env, ptr);
     if (dict == NULL) {
         // remove dictionary
         return ZSTD_DCtx_loadDictionary(dctx, NULL, 0);
@@ -560,13 +560,13 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_loadDDict0
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_reset0
-  (JNIEnv *env, jclass clazz, jlong ptr) {
-    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(intptr_t)ptr;
+  (JNIEnv *env, jclass clazz, jobject ptr) {
+    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(*env)->GetMemoryAddress(env, ptr);
     return ZSTD_DCtx_reset(dctx, ZSTD_reset_session_and_parameters);
 }
 
 static size_t decompress_direct_buffer_stream
-  (JNIEnv *env, jlong ptr, jobject dst, jint *dst_offset, jint dst_size, jobject src, jint *src_offset, jint src_size)
+  (JNIEnv *env, jobject ptr, jobject dst, jint *dst_offset, jint dst_size, jobject src, jint *src_offset, jint src_size)
 {
     if (NULL == dst) return -ZSTD_error_dstSize_tooSmall;
     if (NULL == src) return -ZSTD_error_srcSize_wrong;
@@ -580,7 +580,7 @@ static size_t decompress_direct_buffer_stream
     jsize src_cap = (*env)->GetDirectBufferCapacity(env, src);
     if (src_size > src_cap) return -ZSTD_error_srcSize_wrong;
 
-    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(intptr_t)ptr;
+    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(*env)->GetMemoryAddress(env, ptr);
 
     ZSTD_outBuffer out;
     out.pos = *dst_offset;
@@ -605,7 +605,7 @@ static size_t decompress_direct_buffer_stream
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_decompressDirectByteBufferStream0
-  (JNIEnv *env, jclass jclazz, jlong ptr, jobject dst, jint dst_offset, jint dst_size, jobject src, jint src_offset, jint src_size)
+  (JNIEnv *env, jclass jclazz, jobject ptr, jobject dst, jint dst_offset, jint dst_size, jobject src, jint src_offset, jint src_size)
 {
     size_t result = decompress_direct_buffer_stream(env, ptr, dst, &dst_offset, dst_size, src, &src_offset, src_size);
     if (ZSTD_isError(result)) {
@@ -625,7 +625,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_decompressD
  * Signature: (JLjava/nio/ByteBuffer;IILjava/nio/ByteBuffer;II)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_decompressDirectByteBuffer0
-(JNIEnv *env, jclass jclazz, jlong ptr, jobject dst, jint dst_offset, jint dst_size, jobject src, jint src_offset, jint src_size)
+(JNIEnv *env, jclass jclazz, jobject ptr, jobject dst, jint dst_offset, jint dst_size, jobject src, jint src_offset, jint src_size)
 {
     if (NULL == dst) return -ZSTD_error_dstSize_tooSmall;
     if (NULL == src) return -ZSTD_error_srcSize_wrong;
@@ -638,7 +638,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_decompressD
     jsize src_cap = (*env)->GetDirectBufferCapacity(env, src);
     if (src_offset + src_size > src_cap) return -ZSTD_error_srcSize_wrong;
 
-    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(intptr_t)ptr;
+    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(*env)->GetMemoryAddress(env, ptr);
 
     char *dst_buff = (char*)(*env)->GetDirectBufferAddress(env, dst);
     if (dst_buff == NULL) return -ZSTD_error_memory_allocation;
@@ -655,7 +655,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_decompressD
  * Signature: (B[IIB[II)J
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_decompressByteArray0
-  (JNIEnv *env, jclass jclazz, jlong ptr, jbyteArray dst, jint dst_offset, jint dst_size, jbyteArray src, jint src_offset, jint src_size) {
+  (JNIEnv *env, jclass jclazz, jobject ptr, jbyteArray dst, jint dst_offset, jint dst_size, jbyteArray src, jint src_offset, jint src_size) {
     size_t size = -ZSTD_error_memory_allocation;
 
     if (0 > dst_offset) return -ZSTD_error_dstSize_tooSmall;
@@ -665,7 +665,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdDecompressCtx_decompressB
     if (src_offset + src_size > (*env)->GetArrayLength(env, src)) return -ZSTD_error_srcSize_wrong;
     if (dst_offset + dst_size > (*env)->GetArrayLength(env, dst)) return -ZSTD_error_dstSize_tooSmall;
 
-    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(intptr_t)ptr;
+    ZSTD_DCtx* dctx = (ZSTD_DCtx*)(*env)->GetMemoryAddress(env, ptr);
 
     void *dst_buff = (*env)->GetPrimitiveArrayCritical(env, dst, NULL);
     if (dst_buff == NULL) goto E1;

--- a/src/main/native/jni_inputstream_zstd.c
+++ b/src/main/native/jni_inputstream_zstd.c
@@ -33,9 +33,9 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdInputStreamNoFinalizer_re
  * Method:    createDStream
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdInputStreamNoFinalizer_createDStream
+JNIEXPORT jobject JNICALL Java_com_github_luben_zstd_ZstdInputStreamNoFinalizer_createDStream
   (JNIEnv *env, jclass obj) {
-    return (jlong)(intptr_t) ZSTD_createDStream();
+    return (*env)->NewMemoryAddress(env, ZSTD_createDStream());
 }
 
 /*
@@ -45,7 +45,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdInputStreamNoFinalizer_cr
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdInputStreamNoFinalizer_freeDStream
   (JNIEnv *env, jclass obj, jobject stream) {
-    return ZSTD_freeDCtx((ZSTD_DCtx *)(intptr_t) stream);
+    return ZSTD_freeDCtx((ZSTD_DCtx *)(*env)->GetMemoryAddress(env, stream));
 }
 
 /*
@@ -83,7 +83,7 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdInputStreamNoFinalizer_dec
     ZSTD_outBuffer output = { dst_buff, dst_size, dst_pos };
     ZSTD_inBuffer input = { src_buff, src_size, src_pos };
 
-    size = ZSTD_decompressStream((ZSTD_DCtx *)(intptr_t) stream, &output, &input);
+    size = ZSTD_decompressStream((ZSTD_DCtx *)(*env)->GetMemoryAddress(env, stream), &output, &input);
 
     (*env)->ReleasePrimitiveArrayCritical(env, src, src_buff, JNI_ABORT);
 E2: (*env)->ReleasePrimitiveArrayCritical(env, dst, dst_buff, 0);

--- a/src/main/native/jni_inputstream_zstd.c
+++ b/src/main/native/jni_inputstream_zstd.c
@@ -44,7 +44,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdInputStreamNoFinalizer_cr
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdInputStreamNoFinalizer_freeDStream
-  (JNIEnv *env, jclass obj, jlong stream) {
+  (JNIEnv *env, jclass obj, jobject stream) {
     return ZSTD_freeDCtx((ZSTD_DCtx *)(intptr_t) stream);
 }
 
@@ -54,7 +54,7 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdInputStreamNoFinalizer_fre
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdInputStreamNoFinalizer_initDStream
-  (JNIEnv *env, jclass obj, jlong stream) {
+  (JNIEnv *env, jclass obj, jobject stream) {
     jclass clazz = (*env)->GetObjectClass(env, obj);
     // Initialize the fields ids only once - they can't change
     src_pos_id = (*env)->GetFieldID(env, clazz, "srcPos", "J");
@@ -68,7 +68,7 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdInputStreamNoFinalizer_ini
  * Signature: (J[BI[BI)I
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdInputStreamNoFinalizer_decompressStream
-  (JNIEnv *env, jclass obj, jlong stream, jbyteArray dst, jint dst_size, jbyteArray src, jint src_size) {
+  (JNIEnv *env, jclass obj, jobject stream, jbyteArray dst, jint dst_size, jbyteArray src, jint src_size) {
 
     size_t size = -ZSTD_error_memory_allocation;
 

--- a/src/main/native/jni_outputstream_zstd.c
+++ b/src/main/native/jni_outputstream_zstd.c
@@ -23,9 +23,9 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_r
  * Method:    createCStream
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_createCStream
+JNIEXPORT jobject JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_createCStream
   (JNIEnv *env, jclass obj) {
-    return (jlong)(intptr_t) ZSTD_createCStream();
+    return (*env)->NewMemoryAddress(env, ZSTD_createCStream());
 }
 
 /*
@@ -35,7 +35,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_c
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_freeCStream
   (JNIEnv *env, jclass obj, jobject stream) {
-    return ZSTD_freeCStream((ZSTD_CStream *)(intptr_t) stream);
+    return ZSTD_freeCStream((ZSTD_CStream *)(*env)->GetMemoryAddress(env, stream));
 }
 
 /*
@@ -48,7 +48,7 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_re
     jclass clazz = (*env)->GetObjectClass(env, obj);
     src_pos_id = (*env)->GetFieldID(env, clazz, "srcPos", "J");
     dst_pos_id = (*env)->GetFieldID(env, clazz, "dstPos", "J");
-    return ZSTD_CCtx_reset((ZSTD_CStream *)(intptr_t) stream, ZSTD_reset_session_only);
+    return ZSTD_CCtx_reset((ZSTD_CStream *)(*env)->GetMemoryAddress(env, stream), ZSTD_reset_session_only);
 }
 
 /*
@@ -70,7 +70,7 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_co
     ZSTD_outBuffer output = { dst_buff, dst_size, 0 };
     ZSTD_inBuffer input = { src_buff, src_size, src_pos };
 
-    size = ZSTD_compressStream2((ZSTD_CStream *)(intptr_t) stream, &output, &input, ZSTD_e_continue);
+    size = ZSTD_compressStream2((ZSTD_CStream *)(*env)->GetMemoryAddress(env, stream), &output, &input, ZSTD_e_continue);
 
     (*env)->ReleasePrimitiveArrayCritical(env, src, src_buff, JNI_ABORT);
 E2: (*env)->ReleasePrimitiveArrayCritical(env, dst, dst_buff, 0);
@@ -92,7 +92,7 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_en
     if (dst_buff != NULL) {
         ZSTD_outBuffer output = { dst_buff, dst_size, 0 };
         ZSTD_inBuffer input = {NULL, 0, 0};
-        size = ZSTD_compressStream2((ZSTD_CStream *)(intptr_t) stream, &output, &input, ZSTD_e_end);
+        size = ZSTD_compressStream2((ZSTD_CStream *)(*env)->GetMemoryAddress(env, stream), &output, &input, ZSTD_e_end);
         (*env)->ReleasePrimitiveArrayCritical(env, dst, dst_buff, 0);
         (*env)->SetLongField(env, obj, dst_pos_id, output.pos);
     }
@@ -112,7 +112,7 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_fl
     if (dst_buff != NULL) {
         ZSTD_outBuffer output = { dst_buff, dst_size, 0 };
         ZSTD_inBuffer input = {NULL, 0, 0};
-        size = ZSTD_compressStream2((ZSTD_CStream *)(intptr_t) stream, &output, &input, ZSTD_e_flush);
+        size = ZSTD_compressStream2((ZSTD_CStream *)(*env)->GetMemoryAddress(env, stream), &output, &input, ZSTD_e_flush);
         (*env)->ReleasePrimitiveArrayCritical(env, dst, dst_buff, 0);
         (*env)->SetLongField(env, obj, dst_pos_id, output.pos);
     }

--- a/src/main/native/jni_outputstream_zstd.c
+++ b/src/main/native/jni_outputstream_zstd.c
@@ -34,7 +34,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_c
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_freeCStream
-  (JNIEnv *env, jclass obj, jlong stream) {
+  (JNIEnv *env, jclass obj, jobject stream) {
     return ZSTD_freeCStream((ZSTD_CStream *)(intptr_t) stream);
 }
 
@@ -44,7 +44,7 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_fr
  * Signature: (JII)I
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_resetCStream
-  (JNIEnv *env, jclass obj, jlong stream) {
+  (JNIEnv *env, jclass obj, jobject stream) {
     jclass clazz = (*env)->GetObjectClass(env, obj);
     src_pos_id = (*env)->GetFieldID(env, clazz, "srcPos", "J");
     dst_pos_id = (*env)->GetFieldID(env, clazz, "dstPos", "J");
@@ -57,7 +57,7 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_re
  * Signature: (J[BI[BI)I
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_compressStream
-  (JNIEnv *env, jclass obj, jlong stream, jbyteArray dst, jint dst_size, jbyteArray src, jint src_size) {
+  (JNIEnv *env, jclass obj, jobject stream, jbyteArray dst, jint dst_size, jbyteArray src, jint src_size) {
 
     size_t size = -ZSTD_error_memory_allocation;
 
@@ -85,7 +85,7 @@ E1: return (jint) size;
  * Signature: (J[BI)I
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_endStream
-  (JNIEnv *env, jclass obj, jlong stream, jbyteArray dst, jint dst_size) {
+  (JNIEnv *env, jclass obj, jobject stream, jbyteArray dst, jint dst_size) {
 
     size_t size = -ZSTD_error_memory_allocation;
     void *dst_buff = (*env)->GetPrimitiveArrayCritical(env, dst, NULL);
@@ -105,7 +105,7 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_en
  * Signature: (J[BI)I
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_ZstdOutputStreamNoFinalizer_flushStream
-  (JNIEnv *env, jclass obj, jlong stream, jbyteArray dst, jint dst_size) {
+  (JNIEnv *env, jclass obj, jobject stream, jbyteArray dst, jint dst_size) {
 
     size_t size = -ZSTD_error_memory_allocation;
     void *dst_buff = (*env)->GetPrimitiveArrayCritical(env, dst, NULL);

--- a/src/main/native/jni_zstd.c
+++ b/src/main/native/jni_zstd.c
@@ -219,11 +219,11 @@ E1:
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_loadFastDictDecompress
-  (JNIEnv *env, jclass obj, jobject stream, jobject dict_native_ptr) {
-    // jclass dict_clazz = (*env)->GetObjectClass(env, dict);
-    // jfieldID decompress_dict = (*env)->GetFieldID(env, dict_clazz, "nativePtr", "J");
-    // ZSTD_DDict* ddict = (ZSTD_DDict*)(intptr_t)(*env)->GetLongField(env, dict, decompress_dict);
-    ZSTD_DDict* ddict = (ZSTD_DDict*)(*env)->GetMemoryAddress(env, dict_native_ptr);
+  (JNIEnv *env, jclass obj, jobject stream, jobject dict) {
+    jclass dict_clazz = (*env)->GetObjectClass(env, dict);
+    jfieldID decompress_dict = (*env)->GetFieldID(env, dict_clazz, "nativePtr", "Ljava/lang/MemoryAddress;");
+    ZSTD_DDict* ddict = (ZSTD_DDict*)(*env)->GetMemoryAddress(env, (*env)->GetObjectField(env, dict, decompress_dict));
+    // ZSTD_DDict* ddict = (ZSTD_DDict*)(*env)->GetMemoryAddress(env, dict_native_ptr);
     if (ddict == NULL) return -ZSTD_error_dictionary_wrong;
     return ZSTD_DCtx_refDDict((ZSTD_DCtx *) (*env)->GetMemoryAddress(env, stream), ddict);
 }
@@ -252,10 +252,10 @@ E1:
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_loadFastDictCompress
-  (JNIEnv *env, jclass obj, jobject stream, jobject dict_native_ptr) {
-    // jclass dict_clazz = (*env)->GetObjectClass(env, dict);
-    // jfieldID compress_dict = (*env)->GetFieldID(env, dict_clazz, "nativePtr", "Ljava/lang/MemoryAddress;");
-    // ZSTD_CDict* cdict = (ZSTD_CDict*)(*env)->GetMemoryAddress(env, (*env)->GetObjectField(env, dict, compress_dict));
+  (JNIEnv *env, jclass obj, jobject stream, jobject dict) {
+    jclass dict_clazz = (*env)->GetObjectClass(env, dict);
+    jfieldID compress_dict = (*env)->GetFieldID(env, dict_clazz, "nativePtr", "Ljava/lang/MemoryAddress;");
+    ZSTD_CDict* cdict = (ZSTD_CDict*)(*env)->GetMemoryAddress(env, (*env)->GetObjectField(env, dict, compress_dict));
     ZSTD_CDict* cdict = (ZSTD_CDict*)(*env)->GetMemoryAddress(env, dict_native_ptr);
     if (cdict == NULL) return -ZSTD_error_dictionary_wrong;
     return ZSTD_CCtx_refCDict((ZSTD_CCtx *)(*env)->GetMemoryAddress(env, stream), cdict);

--- a/src/main/native/jni_zstd.c
+++ b/src/main/native/jni_zstd.c
@@ -49,7 +49,7 @@ static size_t JNI_ZSTD_decompressedSize(const void* buf, size_t bufSize, jboolea
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_Zstd_compressUnsafe
   (JNIEnv *env, jclass obj, jobject dst_buf_ptr, jlong dst_size, jobject src_buf_ptr, jlong src_size, jint level, jboolean checksumFlag) {
-    return JNI_ZSTD_compress((*env)->GetMemoryAddress(dst_buf_ptr), (size_t) dst_size, (*env)->GetMemoryAddress(src_buf_ptr), (size_t) src_size, (int) level, checksumFlag);
+    return JNI_ZSTD_compress((*env)->GetMemoryAddress(env, dst_buf_ptr), (size_t) dst_size, (*env)->GetMemoryAddress(env, src_buf_ptr), (size_t) src_size, (int) level, checksumFlag);
 }
 
 /*
@@ -59,7 +59,7 @@ JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_Zstd_compressUnsafe
  */
 JNIEXPORT jlong JNICALL Java_com_github_luben_zstd_Zstd_decompressUnsafe
   (JNIEnv *env, jclass obj, jobject dst_buf_ptr, jlong dst_size, jobject src_buf_ptr, jlong src_size) {
-    return ZSTD_decompress((*env)->GetMemoryAddress(dst_buf_ptr), (size_t) dst_size, (*env)->GetMemoryAddress(src_buf_ptr), (size_t) src_size);
+    return ZSTD_decompress((*env)->GetMemoryAddress(env, dst_buf_ptr), (size_t) dst_size, (*env)->GetMemoryAddress(env, src_buf_ptr), (size_t) src_size);
 }
 
 /*
@@ -223,7 +223,6 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_loadFastDictDecompress
     jclass dict_clazz = (*env)->GetObjectClass(env, dict);
     jfieldID decompress_dict = (*env)->GetFieldID(env, dict_clazz, "nativePtr", "Ljava/lang/MemoryAddress;");
     ZSTD_DDict* ddict = (ZSTD_DDict*)(*env)->GetMemoryAddress(env, (*env)->GetObjectField(env, dict, decompress_dict));
-    // ZSTD_DDict* ddict = (ZSTD_DDict*)(*env)->GetMemoryAddress(env, dict_native_ptr);
     if (ddict == NULL) return -ZSTD_error_dictionary_wrong;
     return ZSTD_DCtx_refDDict((ZSTD_DCtx *) (*env)->GetMemoryAddress(env, stream), ddict);
 }
@@ -256,7 +255,6 @@ JNIEXPORT jint JNICALL Java_com_github_luben_zstd_Zstd_loadFastDictCompress
     jclass dict_clazz = (*env)->GetObjectClass(env, dict);
     jfieldID compress_dict = (*env)->GetFieldID(env, dict_clazz, "nativePtr", "Ljava/lang/MemoryAddress;");
     ZSTD_CDict* cdict = (ZSTD_CDict*)(*env)->GetMemoryAddress(env, (*env)->GetObjectField(env, dict, compress_dict));
-    ZSTD_CDict* cdict = (ZSTD_CDict*)(*env)->GetMemoryAddress(env, dict_native_ptr);
     if (cdict == NULL) return -ZSTD_error_dictionary_wrong;
     return ZSTD_CCtx_refCDict((ZSTD_CCtx *)(*env)->GetMemoryAddress(env, stream), cdict);
 }


### PR DESCRIPTION
- The Java code of `zstd-jni` now wraps all native pointers within `java/lang/MemoryAddress` objects
- The native code of `zstd-jni` now handles `java/lang/MemoryAddress` objects - before a native pointer is passed from native code to Java it is wrapped in a `MemoryAddress` object, and when a `MemoryAddress` object is passed from Java to native code it is unwrapped into native pointer form.
- Also the build of `zstd-jni` had to be updated to work for `FreeBSD aarch64` - and in its current state the build only works for this OS-architecture combination (this was to fix a bug that occurred when other OS-architecture combinations were included, but this could be revisited in the future to reinstate the other OS-architecture combinations)